### PR TITLE
Remove unused hashie dependency

### DIFF
--- a/minfraud.gemspec
+++ b/minfraud.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9', '>= 0.9.1'
-  spec.add_runtime_dependency 'hashie', '~> 3.0'
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Unless I'm missing something really fundamental, I can't see any use of the Hashie gem?

So I propose removing the dependency on it - all the tests still pass without it.