### PR TITLE
Add email_change and password_reset event types to Event

### DIFF
--- a/lib/minfraud/components/event.rb
+++ b/lib/minfraud/components/event.rb
@@ -17,7 +17,17 @@ module Minfraud
 
       # @attribute type
       # @return [String] The type of event being scored
-      enum_accessor :type, [:account_creation, :account_login, :purchase, :recurring_purchase, :referral, :survey]
+      enum_accessor :type,
+        [
+          :account_creation,
+          :account_login,
+          :email_change,
+          :password_reset,
+          :purchase,
+          :recurring_purchase,
+          :referral,
+          :survey,
+        ]
 
       # Creates Minfraud::Components::Event instance
       # @param  [Hash] params hash of parameters

--- a/spec/components/event_spec.rb
+++ b/spec/components/event_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Minfraud::Components::Event do
+  describe '#initialize' do
+    context 'with an invalid type' do
+      it 'raises an exception' do
+        expect {
+          described_class.new({ type: :nonsense })
+        }.to raise_exception(Minfraud::NotEnumValueError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Per the [minFraud release notes](https://dev.maxmind.com/minfraud/release-notes/) from October 10, 2016:
> We have added two new event types to the /event/type field for all minFraud requests, email_change and password_reset. 

This PR:
1. Introduces those 2 new event `type` values to Event
1. Adds a bit of test coverage for Event

Side note:  Thanks for creating this gem, Yuriy!