### PR TITLE
Handle ACCOUNT_ID_REQUIRED error and update some text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ gem install minfraud
 
 ## Configuration
 
-User Id and License Key are required to work with minFraud API
+Account ID and License Key are required to work with minFraud API
 
 ```ruby
 Minfraud.configure do |c|
@@ -86,7 +86,7 @@ class RequestFormatError < BaseError; end
 # Raised if IP address is absent / it is reserved / JSON body can not be decoded
 class ClientError < BaseError; end
 
-# Raised if there are some problems with the user id and / or license key
+# Raised if there are some problems with the account ID and / or license key
 class AuthorizationError < BaseError; end
 
 # Raised if minFraud returns an error, or if there is an HTTP error

--- a/lib/minfraud.rb
+++ b/lib/minfraud.rb
@@ -27,7 +27,7 @@ require 'minfraud/assessments'
 module Minfraud
   class << self
     # @!attribute user_id
-    # @return [String] MaxMind username that is used for authorization
+    # @return [String] MaxMind account ID that is used for authorization
     attr_accessor :user_id
 
     # @!attribute license_key

--- a/lib/minfraud/error_handler.rb
+++ b/lib/minfraud/error_handler.rb
@@ -24,14 +24,17 @@ module Minfraud
         JSON_INVALID:          [
           ClientError, 'JSON body cannot be decoded'
         ],
+        ACCOUNT_ID_REQUIRED:      [
+          AuthorizationError, 'You have not supplied a account ID'
+        ],
         AUTHORIZATION_INVALID: [
-          AuthorizationError, 'Invalid license key and / or user id'
+          AuthorizationError, 'Invalid license key and / or account ID'
         ],
         LICENSE_KEY_REQUIRED:  [
           AuthorizationError, 'You have not supplied a license key'
         ],
         USER_ID_REQUIRED:      [
-          AuthorizationError, 'You have not supplied a user id'
+          AuthorizationError, 'You have not supplied a account id'
         ],
         INSUFFICIENT_FUNDS:    [
           ClientError, 'The license key you have provided does not have a sufficient funds to use this service'


### PR DESCRIPTION
MaxMind is renaming "user ID" to "account ID" for basic auth as we roll out multi-user accounts. In doing this, we will be updating the error code returned by the service from `USER_ID_REQUIRED` to `ACCOUNT_ID_REQUIRED`. This PR supports both the new and old error code. It also updates some references to "user ID". It does not change change the accessor on `Minfraud` as I was not sure how you wanted to handle that.